### PR TITLE
Fix error from missing directory

### DIFF
--- a/mopidy/Dockerfile
+++ b/mopidy/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get purge --auto-remove -y \
        gcc \
        && apt-get clean \
        && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* ~/.cache \
+       && mkdir -p /var/lib/mopidy/.config \
        && chown mopidy:audio -R /var/lib/mopidy/.config
 
 COPY mopidy.conf /var/lib/mopidy/.config/mopidy/mopidy.conf


### PR DESCRIPTION
I'm getting this error on `docker-compose up` during the build of the mopidy image:

```
chown: cannot access '/var/lib/mopidy/.config': No such file or directory
ERROR: Service 'mopidy' failed to build: The command '/bin/sh -c apt-get purge --auto-remove -y        curl        gcc        && ap
t-get clean        && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* ~/.cache        && chown mopidy:audio -R /var/lib/mopidy/.confi
g' returned a non-zero code: 1
```

I believe the directory needs to be created first. This change allowed me to get past the error.